### PR TITLE
Feat(Stream): Use redis stream

### DIFF
--- a/arq/constants.py
+++ b/arq/constants.py
@@ -1,9 +1,12 @@
 default_queue_name = 'arq:queue'
 job_key_prefix = 'arq:job:'
 in_progress_key_prefix = 'arq:in-progress:'
+job_message_id_prefix = 'arq:message-id:'
 result_key_prefix = 'arq:result:'
 retry_key_prefix = 'arq:retry:'
 abort_jobs_ss = 'arq:abort'
+stream_key_suffix = ':stream'
+default_consumer_group = 'arq:consumers'
 # age of items in the abort_key sorted set after which they're deleted
 abort_job_max_age = 60
 health_check_key_suffix = ':health-check'

--- a/arq/lua_script.py
+++ b/arq/lua_script.py
@@ -1,0 +1,24 @@
+publish_job_lua = """
+local stream_key = KEYS[1]
+local job_message_id_key = KEYS[2]
+local job_id = ARGV[1]
+local score = ARGV[2]
+local job_message_id_expire_ms = ARGV[3]
+local message_id = redis.call('xadd', stream_key, '*', 'job_id', job_id, 'score', score)
+redis.call('set', job_message_id_key, message_id, 'px', job_message_id_expire_ms)
+return message_id
+"""
+
+get_job_from_stream_lua = """
+local stream_key = KEYS[1]
+local job_message_id_key = KEYS[2]
+local message_id = redis.call('get', job_message_id_key)
+if message_id == false then
+    return nil
+end
+local job = redis.call('xrange', stream_key, message_id, message_id)
+if job == nil then
+    return nil
+end
+return job[1]
+"""

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -148,3 +148,6 @@ def import_string(dotted_path: str) -> Any:
         return getattr(module, class_name)
     except AttributeError as e:
         raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute') from e
+
+def _list_to_dict(input_list: list[Any]) -> dict[Any, Any]:
+    return dict(zip(input_list[::2], input_list[1::2], strict=True))

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -3,12 +3,14 @@ import contextlib
 import inspect
 import logging
 import signal
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from signal import Signals
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from uuid import uuid4
 
 from redis.exceptions import ResponseError, WatchError
 
@@ -19,15 +21,19 @@ from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (
     abort_job_max_age,
     abort_jobs_ss,
+    default_consumer_group,
     default_queue_name,
     expires_extra_ms,
     health_check_key_suffix,
     in_progress_key_prefix,
     job_key_prefix,
+    job_message_id_prefix,
     keep_cronjob_progress,
     result_key_prefix,
     retry_key_prefix,
+    stream_key_suffix,
 )
+from .lua_script import publish_job_lua
 from .utils import (
     args_to_string,
     import_string,
@@ -57,6 +63,13 @@ class Function:
     max_tries: Optional[int]
 
 
+@dataclass
+class JobMetaInfo:
+    message_id: str | None
+    job_id: str
+    score: int | None
+
+
 def func(
     coroutine: Union[str, Function, 'WorkerCoroutine'],
     *,
@@ -81,7 +94,7 @@ def func(
 
     if isinstance(coroutine, str):
         name = name or coroutine
-        coroutine_: WorkerCoroutine = import_string(coroutine)
+        coroutine_: 'WorkerCoroutine' = import_string(coroutine)
     else:
         coroutine_ = coroutine
 
@@ -187,8 +200,10 @@ class Worker:
         self,
         functions: Sequence[Union[Function, 'WorkerCoroutine']] = (),
         *,
-        distribution_index: Optional[int] = None,
         queue_name: Optional[str] = default_queue_name,
+        use_stream: bool = False,
+        consumer_group_name: str = default_consumer_group,
+        worker_id: Optional[str] = None,
         cron_jobs: Optional[Sequence[CronJob]] = None,
         redis_settings: Optional[RedisSettings] = None,
         redis_pool: Optional[ArqRedis] = None,
@@ -205,6 +220,7 @@ class Worker:
         keep_result: 'SecondsTimedelta' = 3600,
         keep_result_forever: bool = False,
         poll_delay: 'SecondsTimedelta' = 0.5,
+        stream_block: 'SecondsTimedelta' = 0.5,
         queue_read_limit: Optional[int] = None,
         max_tries: int = 5,
         health_check_interval: 'SecondsTimedelta' = 3600,
@@ -218,6 +234,8 @@ class Worker:
         expires_extra_ms: int = expires_extra_ms,
         timezone: Optional[timezone] = None,
         log_results: bool = True,
+        max_consumer_inactivity: 'SecondsTimedelta' = 86400,
+        idle_consumer_poll_interval: 'SecondsTimedelta' = 60,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
         if queue_name is None:
@@ -225,11 +243,10 @@ class Worker:
                 queue_name = redis_pool.default_queue_name
             else:
                 raise ValueError('If queue_name is absent, redis_pool must be present.')
-
-        if distribution_index is not None:
-            queue_name = f'{queue_name}_{distribution_index}'
-
         self.queue_name = queue_name
+        self.use_stream = use_stream
+        self.consumer_group_name = consumer_group_name
+        self.worker_id = worker_id or str(uuid4().hex)
         self.cron_jobs: List[CronJob] = []
         if cron_jobs is not None:
             if not all(isinstance(cj, CronJob) for cj in cron_jobs):
@@ -253,6 +270,9 @@ class Worker:
         self.keep_result_s = to_seconds(keep_result)
         self.keep_result_forever = keep_result_forever
         self.poll_delay_s = to_seconds(poll_delay)
+        self.stream_block_s = to_seconds(stream_block)
+        self.max_consumer_inactivity_s = to_seconds(max_consumer_inactivity)
+        self.idle_consumer_poll_interval_s = to_seconds(idle_consumer_poll_interval)
         self.queue_read_limit = queue_read_limit or max(max_jobs * 5, 100)
         self._queue_read_offset = 0
         self.max_tries = max_tries
@@ -300,6 +320,7 @@ class Worker:
         self.job_deserializer = job_deserializer
         self.expires_extra_ms = expires_extra_ms
         self.log_results = log_results
+        self.publish_job_sha = None
 
         # default to system timezone
         self.timezone = datetime.now().astimezone().tzinfo if timezone is None else timezone
@@ -356,23 +377,129 @@ class Worker:
                 expires_extra_ms=self.expires_extra_ms,
             )
 
+        if self.use_stream:
+            self.publish_job_sha = await self.pool.script_load(publish_job_lua)
+
         logger.info('Starting worker for %d functions: %s', len(self.functions), ', '.join(self.functions))
         await log_redis_info(self.pool, logger.info)
         self.ctx['redis'] = self.pool
         if self.on_startup:
             await self.on_startup(self.ctx)
 
+            if self.use_stream:
+                await self.create_consumer_group()
+                await self.run_stream_reader()
+            else:
+                await self._run_pool_iteration()
+
+    async def run_stream_reader(self) -> None:
+        while True:
+            await self._read_stream_iteration()
+
+            if await self._is_burst_broken() is True:
+                return None
+
+    async def create_consumer_group(self) -> None:
+        with suppress(ResponseError):
+            await self.pool.xgroup_create(
+                name=self.queue_name + stream_key_suffix,
+                groupname=self.consumer_group_name,
+                id='0',
+                mkstream=True,
+            )
+
+    async def _read_stream_iteration(self) -> None:
+        """
+        Get ids of pending jobs from the stream and start those jobs, remove
+        any finished tasks from self.tasks.
+        """
+        count = self.queue_read_limit
+        if self.burst and self.max_burst_jobs >= 0:
+            burst_jobs_remaining = self.max_burst_jobs - self._jobs_started()
+            if burst_jobs_remaining < 1:
+                return
+            count = min(burst_jobs_remaining, count)
+        if self.allow_pick_jobs:
+            if self.job_counter < self.max_jobs:
+                stream_msgs = await self._get_idle_tasks(count)
+                msgs_count = sum([len(msgs) for _, msgs in stream_msgs])
+
+                count -= msgs_count
+
+                if count > 0:
+                    stream_msgs.extend(
+                        await self.pool.xreadgroup(
+                            groupname=self.consumer_group_name,
+                            consumername=self.worker_id,
+                            streams={self.queue_name + stream_key_suffix: '>'},
+                            count=count,
+                            block=int(max(self.stream_block_s * 1000, 1)),
+                        )
+                    )
+
+                jobs = []
+
+                for _, msgs in stream_msgs:
+                    for msg_id, job in msgs:
+                        jobs.append(
+                            JobMetaInfo(
+                                message_id=msg_id.decode(),
+                                job_id=job[b'job_id'].decode(),
+                                score=int(job[b'score']),
+                            )
+                        )
+
+                await self.start_jobs(jobs)
+
+        if self.allow_abort_jobs:
+            await self._cancel_aborted_jobs()
+
+        for job_id, t in list(self.tasks.items()):
+            if t.done():
+                del self.tasks[job_id]
+                # required to make sure errors in run_job get propagated
+                t.result()
+
+        await self.heart_beat()
+
+    async def _get_idle_tasks(self, count: int) -> list[tuple[bytes, list]]:
+        resp = await self.pool.xautoclaim(
+            self.queue_name + stream_key_suffix,
+            groupname=self.consumer_group_name,
+            consumername=self.worker_id,
+            min_idle_time=int(self.in_progress_timeout_s * 1000),
+            count=count,
+        )
+
+        if not resp:
+            return []
+
+        _, msgs, __ = resp
+        if not msgs:
+            return []
+
+        # cast to the same format as the xreadgroup response
+        return [((self.queue_name + stream_key_suffix).encode(), msgs)]
+
+    async def _run_pool_iteration(self):
         async for _ in poll(self.poll_delay_s):
             await self._poll_iteration()
 
-            if self.burst:
-                if 0 <= self.max_burst_jobs <= self._jobs_started():
-                    await asyncio.gather(*self.tasks.values())
-                    return None
-                queued_jobs = await self.pool.zcard(self.queue_name)
-                if queued_jobs == 0:
-                    await asyncio.gather(*self.tasks.values())
-                    return None
+            if await self._is_burst_broken() is True:
+                return None
+
+    async def _is_burst_broken(self):
+        if self.burst:
+            if 0 <= self.max_burst_jobs <= self._jobs_started():
+                await asyncio.gather(*self.tasks.values())
+                return True
+            queued_jobs = await self.pool.zcard(self.queue_name)
+            if queued_jobs == 0:
+                await asyncio.gather(*self.tasks.values())
+                return True
+
+        return False
+
 
     async def _poll_iteration(self) -> None:
         """
@@ -392,7 +519,8 @@ class Worker:
                     self.queue_name, min=float('-inf'), start=self._queue_read_offset, num=count, max=now
                 )
 
-                await self.start_jobs(job_ids)
+                jobs = [JobMetaInfo(message_id=None, job_id=_id.decode()) for _id in job_ids]
+                await self.start_jobs(jobs)
 
         if self.allow_abort_jobs:
             await self._cancel_aborted_jobs()
@@ -433,11 +561,13 @@ class Worker:
         self.job_counter = self.job_counter - 1
         self.sem.release()
 
-    async def start_jobs(self, job_ids: List[bytes]) -> None:
+    async def start_jobs(self, jobs: list[JobMetaInfo]) -> None:
         """
         For each job id, get the job definition, check it's not running and start it in a task
         """
-        for job_id_b in job_ids:
+        for job in jobs:
+            job_id = job.job_id
+
             await self.sem.acquire()
 
             if self.job_counter >= self.max_jobs:
@@ -446,12 +576,14 @@ class Worker:
 
             self.job_counter = self.job_counter + 1
 
-            job_id = job_id_b.decode()
             in_progress_key = in_progress_key_prefix + job_id
             async with self.pool.pipeline(transaction=True) as pipe:
                 await pipe.watch(in_progress_key)
                 ongoing_exists = await pipe.exists(in_progress_key)
-                score = await pipe.zscore(self.queue_name, job_id)
+                if self.use_stream:
+                    score = job.score
+                else:
+                    score = await pipe.zscore(self.queue_name, job_id)
                 if ongoing_exists or not score or score > timestamp_ms():
                     # job already started elsewhere, or already finished and removed from queue
                     # if score > ts_now,
@@ -471,11 +603,13 @@ class Worker:
                     self.sem.release()
                     logger.debug('multi-exec error, job %s already started elsewhere', job_id)
                 else:
-                    t = self.loop.create_task(self.run_job(job_id, int(score)))
+                    t = self.loop.create_task(self.run_job(job, score))
                     t.add_done_callback(lambda _: self._release_sem_dec_counter_on_complete())
                     self.tasks[job_id] = t
 
-    async def run_job(self, job_id: str, score: int) -> None:  # noqa: C901
+    # sentry_sdk/integrations/arq.py patch_run_job needs to be updated
+    async def run_job(self, job_info: JobMetaInfo, score: int) -> None:  # noqa: C901
+        job_id = job_info.job_id
         start_ms = timestamp_ms()
         async with self.pool.pipeline(transaction=True) as pipe:
             pipe.get(job_key_prefix + job_id)
@@ -509,7 +643,7 @@ class Worker:
                 queue_name=self.queue_name,
                 job_id=job_id,
             )
-            await asyncio.shield(self.finish_failed_job(job_id, result_data_))
+            await asyncio.shield(self.finish_failed_job(job_id, job_info.message_id, result_data_))
 
         if not v:
             logger.warning('job %s expired', job_id)
@@ -566,7 +700,7 @@ class Worker:
                 job_id=job_id,
                 serializer=self.job_serializer,
             )
-            return await asyncio.shield(self.finish_failed_job(job_id, result_data))
+            return await asyncio.shield(self.finish_failed_job(job_id, job_info.message_id, result_data))
 
         result = no_result
         exc_extra = None
@@ -667,6 +801,8 @@ class Worker:
         await asyncio.shield(
             self.finish_job(
                 job_id,
+                job_info.message_id,
+                score,
                 finish,
                 result_data,
                 result_timeout_s,
@@ -682,6 +818,8 @@ class Worker:
     async def finish_job(
         self,
         job_id: str,
+        message_id: str | None,
+        score: int,
         finish: bool,
         result_data: Optional[bytes],
         result_timeout_s: Optional[float],
@@ -692,33 +830,80 @@ class Worker:
         async with self.pool.pipeline(transaction=True) as tr:
             delete_keys = []
             in_progress_key = in_progress_key_prefix + job_id
+            stream_key = self.queue_name + stream_key_suffix
             if keep_in_progress is None:
                 delete_keys += [in_progress_key]
             else:
                 tr.pexpire(in_progress_key, to_ms(keep_in_progress))
 
+            if self.use_stream:
+                tr.xack(
+                    stream_key,
+                    self.consumer_group_name,
+                    message_id,
+                )
+                tr.xdel(stream_key, message_id)
+
             if finish:
                 if result_data:
                     expire = None if keep_result_forever else result_timeout_s
                     tr.set(result_key_prefix + job_id, result_data, px=to_ms(expire))
-                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id]
+                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id, job_message_id_prefix + job_id]
                 tr.zrem(abort_jobs_ss, job_id)
                 tr.zrem(self.queue_name, job_id)
             elif incr_score:
-                tr.zincrby(self.queue_name, incr_score, job_id)
+                if self.use_stream:
+                    job_message_id_expire = score - timestamp_ms() + self.expires_extra_ms
+                    tr.evalsha(
+                        self.publish_job_sha,
+                        2,
+                        # keys
+                        stream_key,
+                        job_message_id_prefix + job_id,
+                        # args
+                        job_id,
+                        str(score + incr_score),
+                        str(job_message_id_expire),
+                    )
+                else:
+                    tr.zincrby(self.queue_name, incr_score, job_id)
+            else:
+                if self.use_stream:
+                    job_message_id_expire = score - timestamp_ms() + self.expires_extra_ms
+                    tr.evalsha(
+                        self.publish_job_sha,
+                        2,
+                        # keys
+                        stream_key,
+                        job_message_id_prefix + job_id,
+                        # args
+                        job_id,
+                        str(score),
+                        str(job_message_id_expire),
+                    )
             if delete_keys:
                 tr.delete(*delete_keys)
             await tr.execute()
 
-    async def finish_failed_job(self, job_id: str, result_data: Optional[bytes]) -> None:
+    async def finish_failed_job(self, job_id: str, message_id: str | None, result_data: Optional[bytes]) -> None:
+        stream_key = self.queue_name + stream_key_suffix
         async with self.pool.pipeline(transaction=True) as tr:
             tr.delete(
                 retry_key_prefix + job_id,
                 in_progress_key_prefix + job_id,
                 job_key_prefix + job_id,
+                job_message_id_prefix + job_id,
             )
             tr.zrem(abort_jobs_ss, job_id)
-            tr.zrem(self.queue_name, job_id)
+            if self.use_stream:
+                tr.xack(
+                    stream_key,
+                    self.consumer_group_name,
+                    message_id,
+                )
+                tr.xdel(stream_key, message_id)
+            else:
+                tr.zrem(self.queue_name, job_id)
             # result_data would only be None if serializing the result fails
             keep_result = self.keep_result_forever or self.keep_result_s > 0
             if result_data is not None and keep_result:  # pragma: no branch
@@ -874,6 +1059,15 @@ class Worker:
         await self.pool.delete(self.health_check_key)
         if self.on_shutdown:
             await self.on_shutdown(self.ctx)
+
+        if self.use_stream:
+            # delete consumer
+            await self.pool.xgroup_delconsumer(
+                name=self.queue_name + stream_key_suffix,
+                groupname=self.consumer_group_name,
+                consumername=self.worker_id,
+            )
+
         await self.pool.close(close_connection_pool=True)
         self._pool = None
 


### PR DESCRIPTION
The whole PR got inspired from these two PR: [here](https://github.com/python-arq/arq/pull/451) and [here](https://github.com/python-arq/arq/pull/492). Also I took a look at this [library](https://github.com/tastyware/streaq) to get some idea.

[First PR](https://github.com/python-arq/arq/pull/451) try to use redis stream but still using [_pool_iteration](https://github.com/python-arq/arq/pull/451/files#diff-6bc16b0b2608a9226aeb5a37f083c6a49ca6c15f1ec457eb7fac3327e2f93c4aR396) which is somehow utilizing the old implementation without any benefit. Not sure what stream feature is actually happening there.
However, it has some nice ideas, like passing the flag to decide whether the user wants to use the stream or not.

On the other hand, the second PR has a more accurate usage of stream, but still has some weird ideas for implementation. On one hand, it assume the user only wants to use stream by [removing the old](https://github.com/python-arq/arq/pull/492/files#diff-27b77fc91f229c8075c3a1fe84186a058cc661154a28b56f2bed8d3ec28549edL175) implementation while enqueuing the job.

The second thing that I didn't like was [registering 3 different task](https://github.com/python-arq/arq/pull/492/files#diff-6bc16b0b2608a9226aeb5a37f083c6a49ca6c15f1ec457eb7fac3327e2f93c4aR388-R390) in the worker:
1. The `run_delayed_queue_poller` always tries to read jobs from the simple queue and put it in the stream. If you take a close look, it has some logic, some places to keep putting the task in the queue, and again read it here and put it in the stream. STRANGE
2. The `run_stream_reader` is the actual method to read tasks from the stream.
3. The `run_idle_consumer_cleanup` also tries to remove idle consumers from the Redis. Imagine if we have multiple workers who always try to clean Redis. Strange again. I try to address removing the consumer in the close method like this [part of the library](https://github.com/tastyware/streaq/blob/master/streaq/worker.py#L1044-L1048). We need to clean up the consumer because we are generating a consumer name each time the worker is brought up. I can't imagine any easy way to consistently generate a unique name for our consumers.

Also I removed [_unclaim_job](https://github.com/python-arq/arq/pull/492/files#diff-6bc16b0b2608a9226aeb5a37f083c6a49ca6c15f1ec457eb7fac3327e2f93c4aR625) from the implementation since from my understanding, the usage was to unclaim any job that consumer is trying to get while it is already taken by another consumer. Well, that is the whole point of using Redis stream to prevent such scenario and it shouldn't happen unless there is something wrong with Redis.

As a final note, I also added some improvements in some places to make the logic more robust, like if self.use_stream